### PR TITLE
fix: 关闭默认开启定位组件

### DIFF
--- a/packages/core/src/services/config/defaultConfig.ts
+++ b/packages/core/src/services/config/defaultConfig.ts
@@ -40,7 +40,7 @@ export const defaultConfig: Partial<IConfig> = {
       type: 'mapStyle',
     },
     {
-      display: true,
+      display: false,
       position: 'bottomright',
       type: 'location',
     },


### PR DESCRIPTION
### PR includes

<!-- Add completed items in this PR, and change [ ] to [x]. -->

- [x]  定位组件调用了V1 服务导致在V2 地图下不兼容，关闭定位默认配置


### Screenshot

| Before | After |
| ------ | ----- |
| ❌     | ✅    |
